### PR TITLE
Dispatch ConsoleEvents::INIT when get console and not at application's boot

### DIFF
--- a/src/Provider/ConsoleServiceProvider.php
+++ b/src/Provider/ConsoleServiceProvider.php
@@ -6,10 +6,8 @@ use Pimple\ServiceProviderInterface;
 use Pimple\Container;
 use Quazardous\Silex\Console\ConsoleEvent;
 use Quazardous\Silex\Console\ConsoleEvents;
-use Silex\Api\BootableProviderInterface;
-use Silex\Application;
 
-class ConsoleServiceProvider implements ServiceProviderInterface, BootableProviderInterface
+class ConsoleServiceProvider implements ServiceProviderInterface
 {
     public function register(Container $app)
     {
@@ -33,13 +31,9 @@ class ConsoleServiceProvider implements ServiceProviderInterface, BootableProvid
                 $c['console.version']
             );
 
+            $c['dispatcher']->dispatch(ConsoleEvents::INIT, new ConsoleEvent($console));
+
             return $console;
         };
-    }
-
-    public function boot(Application $app)
-    {
-        // tell everyone the console is ready
-        $app['dispatcher']->dispatch(ConsoleEvents::INIT, new ConsoleEvent($app['console']));
     }
 }


### PR DESCRIPTION
Hi, 

See [this comment](https://github.com/quazardous/silex-console/commit/6338253f5cdf368a8d2cc93aa118f706ce9d4b96#diff-d6cea55d17adcf43a1377c8d89a265a7R40)
