### PR TITLE
Set Silex dispatcher to console application

### DIFF
--- a/src/Console/Console.php
+++ b/src/Console/Console.php
@@ -46,6 +46,7 @@ class Console extends BaseApplication
     {
         $this->setAutoExit(false);
         $this->getContainer()->boot();
+        $this->setDispatcher($this->getContainer()['dispatcher']);
         $this->getContainer()['dispatcher']->dispatch(ConsoleEvents::INIT, new ConsoleEvent($this));
         $this->getContainer()->flush();
         $exitCode = parent::run($input, $output);


### PR DESCRIPTION
Allows to use the events dispatched by the Console Application  as explained in [the documentation](http://symfony.com/doc/current/components/console/events.html).